### PR TITLE
XmlToMapParser nil error

### DIFF
--- a/xml.go
+++ b/xml.go
@@ -300,7 +300,9 @@ func xmlToMapParser(skey string, a []xml.Attr, p *xml.Decoder, r bool) (map[stri
 				if len(na) > 0 {
 					na["#text"] = cast(tt, r)
 				} else {
-					n[skey] = cast(tt, r)
+					if skey != "" {
+						n[skey] = cast(tt, r)
+					}
 				}
 			}
 		default:


### PR DESCRIPTION
I've encountered a case where 'skey' seems to be empty and golang throws 'panic: assignment to entry in nil map'. Adding a check for 'skey' fixes that.