### PR TITLE
Fix build issue

### DIFF
--- a/mxj.go
+++ b/mxj.go
@@ -97,7 +97,7 @@ func writeMap(m interface{}, root bool, offset ...int) string {
 			for i := 0; i < indent; i++ {
 				s += "  "
 			}
-			s += writeMap(v, indent+1)
+			s += writeMap(v, false, indent+1)
 		}
 	case map[string]interface{}:
 		list := make([][2]string, len(m.(map[string]interface{})))


### PR DESCRIPTION
Fixes a build issue:  `../mxj/mxj.go:100: cannot use indent + 1 (type int) as type bool in argument to writeMap`.