### PR TITLE
adding closing tag for tag with attributes only

### DIFF
--- a/xml.go
+++ b/xml.go
@@ -818,6 +818,11 @@ func mapToXmlIndent(doIndent bool, s *string, key string, value interface{}, pp 
 		}
 		// only attributes?
 		if n == lenvv {
+			if useGoXmlEmptyElemSyntax {
+				*s += `</` + key + ">"
+			} else {
+				*s += `/>`
+			}
 			break
 		}
 


### PR DESCRIPTION
Fixed bug with adding closing tag for tag with attributes only.
### Example:
```
dom, err := mxj.NewMapXml([]byte("<memballoon model='virtio'><address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/></memballoon>)"))
xml, err := dom.XmlIndent("", "  ")
```
### Produce:
```
<memballoon model='virtio'>
  <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'
</memballoon>
```
where `address` without closing tag.