### PR TITLE
fix 'NewMapReader' typo

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -45,8 +45,8 @@ SUMMARY
       xmlValue, err := mv.Xml()      // marshal
 
    Unmarshal XML from an io.Reader as a Map value, 'mv':
-      mv, err := NewMapReader(xmlReader)         // repeated calls, as with an os.File Reader, will process stream
-      mv, raw, err := NewMapReaderRaw(xmlReader) // 'raw' is the raw XML that was decoded
+      mv, err := NewMapXmlReader(xmlReader)         // repeated calls, as with an os.File Reader, will process stream
+      mv, raw, err := NewMapXmlReaderRaw(xmlReader) // 'raw' is the raw XML that was decoded
 
    Marshal Map value, 'mv', to an XML Writer (io.Writer):
       err := mv.XmlWriter(xmlWriter)

--- a/readme.md
+++ b/readme.md
@@ -58,8 +58,8 @@ Unmarshal / marshal XML as a `Map` value, 'mv':
 xmlValue, err := mv.Xml()      // marshal</pre>
 
 Unmarshal XML from an `io.Reader` as a `Map` value, 'mv':
-<pre>mv, err := NewMapReader(xmlReader)         // repeated calls, as with an os.File Reader, will process stream
-mv, raw, err := NewMapReaderRaw(xmlReader) // 'raw' is the raw XML that was decoded</pre>
+<pre>mv, err := NewMapXmlReader(xmlReader)         // repeated calls, as with an os.File Reader, will process stream
+mv, raw, err := NewMapXmlReaderRaw(xmlReader) // 'raw' is the raw XML that was decoded</pre>
 
 Marshal `Map` value, 'mv', to an XML Writer (`io.Writer`):
 <pre>err := mv.XmlWriter(xmlWriter)


### PR DESCRIPTION
In `readme.md` and `doc.go`, there is an example for the functions `NewMapXmlReader` and `NewMapXmlReaderRaw`. The example misspells these functions, omitting `Xml` from the function names.

This PR fixes this issue.