### PR TITLE
Remove modifying values

### DIFF
--- a/misc_test.go
+++ b/misc_test.go
@@ -219,6 +219,7 @@ func TestPreserveSpaceDisableByDefault(t *testing.T) {
 func TestPreserveSpaceOn(t *testing.T) {
 	const path = "doc.elem3"
 	TrimValueWhiteSpace(false)
+	defer TrimValueWhiteSpace(true)
 
 	m, err := NewMapXml(whiteSpaceData)
 	if err != nil {

--- a/misc_test.go
+++ b/misc_test.go
@@ -199,6 +199,9 @@ func TestAttributesNoAttrPrefix(t *testing.T) {
 }
 
 func TestPreserveSpace(t *testing.T) {
+	TrimValueWhiteSpace(true)
+	defer TrimValueWhiteSpace(false)
+
 	m, err := NewMapXml([]byte("<a> hello world </a>"))
 	if err != nil {
 		t.Fatal(err)

--- a/misc_test.go
+++ b/misc_test.go
@@ -197,3 +197,18 @@ func TestAttributesNoAttrPrefix(t *testing.T) {
 	}
 	PrependAttrWithHyphen(true)
 }
+
+func TestPreserveSpace(t *testing.T) {
+	m, err := NewMapXml([]byte("<a> hello world </a>"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := m.ValueForPath("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != " hello world " {
+		t.Fatal("Spaces in value was not preserved")
+	}
+	fmt.Printf("'%v'\n", s)
+}

--- a/misc_test.go
+++ b/misc_test.go
@@ -201,56 +201,68 @@ func TestAttributesNoAttrPrefix(t *testing.T) {
 var whiteSpaceData = []byte("<doc><elem3> hello world </elem3></doc>")
 
 func TestPreserveSpaceDisableByDefault(t *testing.T) {
-	const path = "doc.elem3"
-	m, err := NewMapXml(whiteSpaceData)
-	if err != nil {
-		t.Fatal(err)
+	const (
+		path       = "doc.elem3"
+		input      = " hello world "
+		trimmed    = "hello world"
+		notTrimmed = input
+	)
+	tcs := []struct {
+		name           string
+		args           []bool
+		expectedOutput string
+	}{
+		{
+			name:           "Default Preserve Space disabled should trim values",
+			args:           nil, // nil will result in the `DisableWhiteSpace` to be skipped
+			expectedOutput: trimmed,
+		},
+		{
+			name:           "Single true is passed should not trim values",
+			args:           []bool{true},
+			expectedOutput: notTrimmed,
+		},
+		{
+			name:           "Single false is passed should trim values",
+			args:           []bool{false},
+			expectedOutput: trimmed,
+		},
+		{
+			name:           "No args are passed should not trim values",
+			args:           []bool{},
+			expectedOutput: notTrimmed,
+		},
+		{
+			name:           "Extra arguments should be ignored",
+			args:           []bool{true, false},
+			expectedOutput: notTrimmed,
+		},
+		{
+			name:           "Extra arguments should be ignored with false",
+			args:           []bool{false, true},
+			expectedOutput: trimmed,
+		},
 	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.args != nil {
+				DisableTrimWhiteSpace(tc.args...)
+			}
+			m, err := NewMapXml(whiteSpaceData)
 
-	s, err := m.ValueForPath(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if s != "hello world" {
-		t.Fatal("space value was not trimmed")
-	}
-}
+			if err != nil {
+				t.Fatal(err)
+			}
 
-func TestPreserveSpaceOn(t *testing.T) {
-	const path = "doc.elem3"
-	TrimValueWhiteSpace(false)
-	defer TrimValueWhiteSpace(true)
-
-	m, err := NewMapXml(whiteSpaceData)
-	if err != nil {
-		t.Fatal(err)
+			s, err := m.ValueForPath(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if s != tc.expectedOutput {
+				t.Fatalf("expected '%s' got '%s'", tc.expectedOutput, s)
+			}
+		})
 	}
-
-	s, err := m.ValueForPath(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	fmt.Println(' ', s)
-	if s != " hello world " {
-		t.Fatal("space in value was trimmed ")
-	}
-}
-
-func TestPreserveSpaceOff(t *testing.T) {
-	const path = "doc.elem3"
-	TrimValueWhiteSpace(true)
-
-	m, err := NewMapXml(whiteSpaceData)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	s, err := m.ValueForPath(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	fmt.Println(' ', s)
-	if s == " hello world " {
-		t.Fatal("space in value was not trimmed ")
-	}
+	// Set it back to false after all tests are done
+	DisableTrimWhiteSpace(false)
 }

--- a/misc_test.go
+++ b/misc_test.go
@@ -198,20 +198,58 @@ func TestAttributesNoAttrPrefix(t *testing.T) {
 	PrependAttrWithHyphen(true)
 }
 
-func TestPreserveSpace(t *testing.T) {
-	TrimValueWhiteSpace(true)
-	defer TrimValueWhiteSpace(false)
+var whiteSpaceData = []byte("<doc><elem3> hello world </elem3></doc>")
 
-	m, err := NewMapXml([]byte("<a> hello world </a>"))
+func TestPreserveSpaceDisableByDefault(t *testing.T) {
+	const path = "doc.elem3"
+	m, err := NewMapXml(whiteSpaceData)
 	if err != nil {
 		t.Fatal(err)
 	}
-	s, err := m.ValueForPath("a")
+
+	s, err := m.ValueForPath(path)
 	if err != nil {
 		t.Fatal(err)
 	}
+	if s != "hello world" {
+		t.Fatal("space value was not trimmed")
+	}
+}
+
+func TestPreserveSpaceOn(t *testing.T) {
+	const path = "doc.elem3"
+	TrimValueWhiteSpace(false)
+
+	m, err := NewMapXml(whiteSpaceData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := m.ValueForPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(' ', s)
 	if s != " hello world " {
-		t.Fatal("Spaces in value was not preserved")
+		t.Fatal("space in value was trimmed ")
 	}
-	fmt.Printf("'%v'\n", s)
+}
+
+func TestPreserveSpaceOff(t *testing.T) {
+	const path = "doc.elem3"
+	TrimValueWhiteSpace(true)
+
+	m, err := NewMapXml(whiteSpaceData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := m.ValueForPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(' ', s)
+	if s == " hello world " {
+		t.Fatal("space in value was not trimmed ")
+	}
 }

--- a/xml.go
+++ b/xml.go
@@ -238,7 +238,7 @@ func CoerceKeysToLower(b ...bool) {
 // disableTrimWhiteSpace will set if
 var disableTrimWhiteSpace bool
 
-// TrimValueWhiteSpace set where the white space should be trimmed or not. By default white space is always trimmed.
+// TrimValueWhiteSpace set if the white space should be trimmed or not. By default white space is always trimmed.
 func TrimValueWhiteSpace(b bool) {
 	disableTrimWhiteSpace = b
 }
@@ -466,7 +466,6 @@ func xmlToMapParser(skey string, a []xml.Attr, p *xml.Decoder, r bool) (map[stri
 			// clean up possible noise
 			sb := strings.Builder{}
 			sb.WriteString("\t\r\b\n")
-			fmt.Printf("Trim white space? %v\n", disableTrimWhiteSpace)
 			if !disableTrimWhiteSpace {
 				sb.WriteRune(' ')
 			}

--- a/xml.go
+++ b/xml.go
@@ -57,7 +57,7 @@ var XmlCharsetReader func(charset string, input io.Reader) (io.Reader, error)
 //	      extraneous xml.CharData will be ignored unless io.EOF is reached first.
 //	   3. If CoerceKeysToLower() has been called, then all key values will be lower case.
 //	   4. If CoerceKeysToSnakeCase() has been called, then all key values will be converted to snake case.
-//     5. If TrimValueWhiteSpace(b bool) has been called, then all values will be trimmed or not. By default
+//     5. If DisableTrimWhiteSpace(b bool) has been called, then all values will be trimmed or not. By default
 //        this is true.
 func NewMapXml(xmlVal []byte, cast ...bool) (Map, error) {
 	var r bool
@@ -240,9 +240,22 @@ func CoerceKeysToLower(b ...bool) {
 // disableTrimWhiteSpace sets if the white space should be removed or not
 var disableTrimWhiteSpace bool
 
-// TrimValueWhiteSpace set if the white space should be trimmed or not. By default white space is always trimmed.
-func TrimValueWhiteSpace(b bool) {
-	disableTrimWhiteSpace = !b
+var trimRunes = "\t\r\b\n "
+
+// DisableTrimWhiteSpace set if the white space should be trimmed or not. By default white space is always trimmed. If
+// no argument is provided, trim white space will be disabled.
+func DisableTrimWhiteSpace(b ...bool) {
+	if len(b) == 0 {
+		disableTrimWhiteSpace = true
+	} else {
+		disableTrimWhiteSpace = b[0]
+	}
+
+	if disableTrimWhiteSpace {
+		trimRunes = "\t\r\b\n"
+	} else {
+		trimRunes = "\t\r\b\n "
+	}
 }
 
 // 25jun16: Allow user to specify the "prefix" character for XML attribute key labels.
@@ -466,13 +479,7 @@ func xmlToMapParser(skey string, a []xml.Attr, p *xml.Decoder, r bool) (map[stri
 			return n, nil
 		case xml.CharData:
 			// clean up possible noise
-			sb := strings.Builder{}
-			sb.WriteString("\t\r\b\n")
-			if !disableTrimWhiteSpace {
-				sb.WriteRune(' ')
-			}
-
-			tt := strings.Trim(string(t.(xml.CharData)), sb.String())
+			tt := strings.Trim(string(t.(xml.CharData)), trimRunes)
 			if len(tt) > 0 {
 				if len(na) > 0 || decodeSimpleValuesAsMap {
 					na["#text"] = cast(tt, r, "#text")

--- a/xml.go
+++ b/xml.go
@@ -235,6 +235,14 @@ func CoerceKeysToLower(b ...bool) {
 	}
 }
 
+// disableTrimWhiteSpace will set if
+var disableTrimWhiteSpace bool
+
+// TrimValueWhiteSpace set where the white space should be trimmed or not. By default white space is always trimmed.
+func TrimValueWhiteSpace(b bool) {
+	disableTrimWhiteSpace = b
+}
+
 // 25jun16: Allow user to specify the "prefix" character for XML attribute key labels.
 // We do this by replacing '`' constant with attrPrefix var, replacing useHyphen with attrPrefix = "",
 // and adding a SetAttrPrefix(s string) function.
@@ -456,7 +464,14 @@ func xmlToMapParser(skey string, a []xml.Attr, p *xml.Decoder, r bool) (map[stri
 			return n, nil
 		case xml.CharData:
 			// clean up possible noise
-			tt := string(t.(xml.CharData))
+			sb := strings.Builder{}
+			sb.WriteString("\t\r\b\n")
+			fmt.Printf("Trim white space? %v\n", disableTrimWhiteSpace)
+			if !disableTrimWhiteSpace {
+				sb.WriteRune(' ')
+			}
+
+			tt := strings.Trim(string(t.(xml.CharData)), sb.String())
 			if len(tt) > 0 {
 				if len(na) > 0 || decodeSimpleValuesAsMap {
 					na["#text"] = cast(tt, r, "#text")

--- a/xml.go
+++ b/xml.go
@@ -235,12 +235,12 @@ func CoerceKeysToLower(b ...bool) {
 	}
 }
 
-// disableTrimWhiteSpace will set if
+// disableTrimWhiteSpace sets if the white space should be removed or not
 var disableTrimWhiteSpace bool
 
 // TrimValueWhiteSpace set if the white space should be trimmed or not. By default white space is always trimmed.
 func TrimValueWhiteSpace(b bool) {
-	disableTrimWhiteSpace = b
+	disableTrimWhiteSpace = !b
 }
 
 // 25jun16: Allow user to specify the "prefix" character for XML attribute key labels.

--- a/xml.go
+++ b/xml.go
@@ -456,7 +456,7 @@ func xmlToMapParser(skey string, a []xml.Attr, p *xml.Decoder, r bool) (map[stri
 			return n, nil
 		case xml.CharData:
 			// clean up possible noise
-			tt := strings.Trim(string(t.(xml.CharData)), "\t\r\b\n ")
+			tt := string(t.(xml.CharData))
 			if len(tt) > 0 {
 				if len(na) > 0 || decodeSimpleValuesAsMap {
 					na["#text"] = cast(tt, r, "#text")

--- a/xml.go
+++ b/xml.go
@@ -57,6 +57,8 @@ var XmlCharsetReader func(charset string, input io.Reader) (io.Reader, error)
 //	      extraneous xml.CharData will be ignored unless io.EOF is reached first.
 //	   3. If CoerceKeysToLower() has been called, then all key values will be lower case.
 //	   4. If CoerceKeysToSnakeCase() has been called, then all key values will be converted to snake case.
+//     5. If TrimValueWhiteSpace(b bool) has been called, then all values will be trimmed or not. By default
+//        this is true.
 func NewMapXml(xmlVal []byte, cast ...bool) (Map, error) {
 	var r bool
 	if len(cast) == 1 {


### PR DESCRIPTION
At the moment, the xml parser modifies the value returned. This can be an issue the white space should be preserved.

The main issue with this PR is that it will break anything that expects the data to be cleaned. Another option is to include the `xml:space` and require a "preserved" and "default" would be the trim value. 