### PR TITLE
* fix unescaped double quotes (") placed in values of XML attributes

### DIFF
--- a/escapechars.go
+++ b/escapechars.go
@@ -51,13 +51,26 @@ var escapechars = [][2][]byte{
 	{[]byte(`'`), []byte(`&apos;`)},
 }
 
+// Escape double quotes (") in values of attributes to generate correct XML
+var escapeattrchars = [][2][]byte{
+	{[]byte(`"`), []byte(`&quot;`)},
+}
+
 func escapeChars(s string) string {
+	return escapeCharsBySet(s, &escapechars)
+}
+
+func escapeAttribute(s string) string {
+	return escapeCharsBySet(s, &escapeattrchars)
+}
+
+func escapeCharsBySet(s string, set *[][2][]byte) string {
 	if len(s) == 0 {
 		return s
 	}
 
 	b := []byte(s)
-	for _, v := range escapechars {
+	for _, v := range *set {
 		n := bytes.Count(b, v[0])
 		if n == 0 {
 			continue

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/clbanning/mxj/v2
+module github.com/miketobler/mxj/v2
 
 go 1.15

--- a/xml.go
+++ b/xml.go
@@ -1122,13 +1122,13 @@ func marshalMapToXmlIndent(doIndent bool, b *bytes.Buffer, key string, value int
 				if xmlEscapeChars {
 					v = escapeChars(v.(string))
 				} else {
-					v = v.(string)
+					v = escapeAttribute(v.(string))
 				}
 			case []byte:
 				if xmlEscapeChars {
 					v = escapeChars(string(v.([]byte)))
 				} else {
-					v = string(v.([]byte))
+					v = escapeAttribute(string(v.([]byte)))
 				}
 			}
 			if _, err = b.WriteString(">" + fmt.Sprintf("%v", v)); err != nil {

--- a/xmlseq.go
+++ b/xmlseq.go
@@ -626,7 +626,7 @@ func mapToXmlSeqIndent(doIndent bool, s *string, key string, value interface{}, 
 					if xmlEscapeChars {
 						ss = escapeChars(vv["#text"].(string))
 					} else {
-						ss = vv["#text"].(string)
+						ss = escapeAttribute(vv["#text"].(string))
 					}
 					*s += ` ` + a.k + `="` + ss + `"`
 				case float64, bool, int, int32, int64, float32:
@@ -635,7 +635,7 @@ func mapToXmlSeqIndent(doIndent bool, s *string, key string, value interface{}, 
 					if xmlEscapeChars {
 						ss = escapeChars(string(vv["#text"].([]byte)))
 					} else {
-						ss = string(vv["#text"].([]byte))
+						ss = escapeAttribute(string(vv["#text"].([]byte)))
 					}
 					*s += ` ` + a.k + `="` + ss + `"`
 				default:


### PR DESCRIPTION
If value of XML attribute contains double quotes (") and mxj.XMLEscapeChars is false, the library produces invalid XML through XML() function (unescaped double quotes are placed into value of attributes).