### PR TITLE
Add support for whitespace(DisableTrimWhiteSpace) to ordering(MapXmlSeq).

### DIFF
--- a/xmlseq.go
+++ b/xmlseq.go
@@ -342,6 +342,13 @@ func xmlSeqToMapParser(skey string, a []xml.Attr, p *xml.Decoder, r bool) (map[s
 		case xml.CharData:
 			// clean up possible noise
 			tt := strings.Trim(string(t.(xml.CharData)), trimRunes)
+			if trimRunes == "\t\r\b\n" {
+				spaceCount := strings.Count(tt, " ")
+				spaceLength := len(tt)
+				if spaceCount == spaceLength {
+					tt = ""
+				}
+			}
 			if xmlEscapeCharsDecoder { // issue#84
 				tt = escapeChars(tt)
 			}

--- a/xmlseq.go
+++ b/xmlseq.go
@@ -364,13 +364,6 @@ func xmlSeqToMapParser(skey string, a []xml.Attr, p *xml.Decoder, r bool) (map[s
 		case xml.CharData:
 			// clean up possible noise
 			tt := strings.Trim(string(t.(xml.CharData)), trimRunes)
-			if trimRunes == "\t\r\b\n" {
-				spaceCount := strings.Count(tt, " ")
-				spaceLength := len(tt)
-				if spaceCount == spaceLength {
-					tt = ""
-				}
-			}
 			if xmlEscapeCharsDecoder { // issue#84
 				tt = escapeChars(tt)
 			}

--- a/xmlseq_whitespace_test.go
+++ b/xmlseq_whitespace_test.go
@@ -1,0 +1,43 @@
+package mxj
+
+import "testing"
+
+var whiteSpaceDataSeqTest = []byte(`<books>
+   <book seq="1" ser="5">
+      <author>William T. Gaddis </author>
+      <title> The Recognitions </title>
+      <review> One of the great seminal American novels of the 20th century.</review>
+   </book>
+   <book seq="2">
+      <author>Austin Tappan Wright</author>
+      <title>Islandia</title>
+      <review>An example of earlier 20th century American utopian fiction.</review>
+   </book>
+   <book seq="3" ser="6">
+      <author> John Hawkes </author>
+      <title> The Beetle Leg </title>
+      <review> A lyrical novel about the construction of Ft. Peck Dam in Montana. </review>
+   </book>
+</books>`)
+
+func TestNewMapXmlSeqWhiteSpace(t *testing.T) {
+	t.Run("Testing NewMapXMLSeq with WhiteSpacing", func(t *testing.T) {
+		DisableTrimWhiteSpace(true)
+
+		m, err := NewMapXmlSeq(whiteSpaceDataSeqTest)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		m1 := MapSeq(m)
+		x, err := m1.XmlIndent("", "   ")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(x) != string(whiteSpaceDataSeqTest) {
+			t.Fatalf("expected\n'%s' \ngot \n'%s'", whiteSpaceDataSeqTest, x)
+		}
+	})
+	DisableTrimWhiteSpace(false)
+}

--- a/xmlseq_whitespace_test.go
+++ b/xmlseq_whitespace_test.go
@@ -21,10 +21,10 @@ var whiteSpaceDataSeqTest = []byte(`<books>
 </books>`)
 
 func TestNewMapXmlSeqWhiteSpace(t *testing.T) {
-	t.Run("Testing NewMapXMLSeq with WhiteSpacing", func(t *testing.T) {
+	t.Run("Testing NewMapFormattedXmlSeq with WhiteSpacing", func(t *testing.T) {
 		DisableTrimWhiteSpace(true)
 
-		m, err := NewMapXmlSeq(whiteSpaceDataSeqTest)
+		m, err := NewMapFormattedXmlSeq(whiteSpaceDataSeqTest)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
The PR adds support for maintaining whitespace(when enabled with DisableTrimWhiteSpace(true)) when used with XML ordering (MapXmlSeq)! 