### PR TITLE
Add features to mimic xq (from python yq)

### DIFF
--- a/anyxml.go
+++ b/anyxml.go
@@ -114,6 +114,9 @@ func AnyXml(v interface{}, tags ...string) ([]byte, error) {
 	case map[string]interface{}:
 		m := Map(v.(map[string]interface{}))
 		b, err = m.Xml(rt)
+	case Map:
+		m := v.(Map)
+		b, err = m.Xml(rt)
 	default:
 		err = marshalMapToXmlIndent(false, s, rt, v, p)
 		b = s.Bytes()
@@ -191,6 +194,9 @@ func AnyXmlIndent(v interface{}, prefix, indent string, tags ...string) ([]byte,
 		b = s.Bytes()
 	case map[string]interface{}:
 		m := Map(v.(map[string]interface{}))
+		b, err = m.XmlIndent(prefix, indent, rt)
+	case Map:
+		m := v.(Map)
 		b, err = m.XmlIndent(prefix, indent, rt)
 	default:
 		err = marshalMapToXmlIndent(true, s, rt, v, p)

--- a/anyxml_test.go
+++ b/anyxml_test.go
@@ -109,7 +109,6 @@ func TestAnyXmlIndent(t *testing.T) {
 	fmt.Println("s->x:\n", string(x))
 }
 
-
 func TestNilMap(t *testing.T) {
 	XmlDefaultEmptyElemSyntax()
 	checkval := "<root/>"
@@ -205,4 +204,30 @@ func TestNilValue(t *testing.T) {
 		t.Fatal()
 	}
 	XmlDefaultEmptyElemSyntax()
+}
+
+func TestFixRoot(t *testing.T) {
+	val := map[string]interface{}{"toplevel": nil}
+	checkval := "<toplevel/>"
+
+	XmlDefaultEmptyElemSyntax()
+	FixRoot(true)
+
+	xmlout, err := AnyXml(val)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(xmlout) != checkval {
+		fmt.Println(string(xmlout), "!=", checkval)
+		t.Fatal()
+	}
+
+	xmlout, err = AnyXmlIndent(val, "", " ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(xmlout) != checkval {
+		fmt.Println(string(xmlout), "!=", checkval)
+		t.Fatal()
+	}
 }

--- a/xml.go
+++ b/xml.go
@@ -803,7 +803,7 @@ func (mv Map) Xml(rootTag ...string) ([]byte, error) {
 					switch v.(type) {
 					case map[string]interface{}: // noop
 					default: // anything else
-						if len(rootTag) == 0 && fixRoot {
+						if len(rootTag) == 0 {
 							err = marshalMapToXmlIndent(true, b, DefaultRootTag, m, p)
 						} else {
 							err = marshalMapToXmlIndent(true, b, rootTag[0], m, p)
@@ -1063,7 +1063,7 @@ func (mv Map) XmlIndent(prefix, indent string, rootTag ...string) ([]byte, error
 		// use it if it isn't a key for a list
 		for key, value := range m {
 			if _, ok := value.([]interface{}); ok {
-				if len(rootTag) == 0 && fixRoot {
+				if len(rootTag) == 0 {
 					err = marshalMapToXmlIndent(true, b, DefaultRootTag, m, p)
 				} else {
 					err = marshalMapToXmlIndent(true, b, rootTag[0], m, p)

--- a/xml4_test.go
+++ b/xml4_test.go
@@ -1,0 +1,53 @@
+// xml4_test.go - new features KeepNamespece / ForceList
+
+package mxj
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestKeepNamespace(t *testing.T) {
+	src := `<ns:r a="2" ns:b="3"><e>1</e></ns:r>`
+	FixRoot(true)
+	KeepNamespace(true)
+	dom, err := NewMapXml([]byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var domv map[string]interface{}
+	domv = dom
+	xml, err := AnyXml(domv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(xml) != src {
+		fmt.Println(string(xml), "!=", src)
+		t.Fatal()
+	}
+}
+
+func TestForList(t *testing.T) {
+	src := `<r><e>1</e></r>`
+	FixRoot(true)
+	ForceList("r", "e")
+	dom, err := NewMapXml([]byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var domv map[string]interface{}
+	domv = dom
+	if r, ok := domv["r"]; ok {
+		if rr, ok := r.(map[string]interface{}); ok {
+			if e, ok := rr["e"]; ok {
+				if ee, ok := e.([]interface{}); ok {
+					if len(ee) == 1 && ee[0] == "1" {
+						return
+					}
+				}
+			}
+		}
+	}
+	fmt.Printf("%v\n", domv)
+	t.Fatalf("Invalid, must be an array")
+}


### PR DESCRIPTION
Added a few features, without any breaking changes:
- add KeepNamespace() to keep namespaces in input
- add ForceList() to force elements to be arrays
- add FixRoot() to prevent adding root element when map/Map contains only one element

Also added tests for these new features.
