### PR TITLE
Use v2 in import paths, and regenerate go.mod and go.sum

### DIFF
--- a/anyxml.go
+++ b/anyxml.go
@@ -22,7 +22,7 @@ const (
 	import (
 		"encoding/json"
 		"fmt"
-		"github.com/clbanning/mxj"
+		"github.com/clbanning/mxj/v2"
 	)
 
 	func main() {

--- a/example_test.go
+++ b/example_test.go
@@ -11,7 +11,7 @@ import (
 /*
 	"bytes"
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"io"
 */
 )

--- a/examples/append.go
+++ b/examples/append.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var data = []byte(`

--- a/examples/bom.go
+++ b/examples/bom.go
@@ -7,7 +7,7 @@ import (
 	"encoding/xml"
 	"fmt"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 func main() {

--- a/examples/books.go
+++ b/examples/books.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"log"
 )
 

--- a/examples/getmetrics1.go
+++ b/examples/getmetrics1.go
@@ -38,7 +38,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"log"
 	"os"
 	"sort"

--- a/examples/getmetrics2.go
+++ b/examples/getmetrics2.go
@@ -39,7 +39,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"log"
 	"os"
 	"sort"

--- a/examples/getmetrics3.go
+++ b/examples/getmetrics3.go
@@ -40,7 +40,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"log"
 	"os"
 	"sort"

--- a/examples/getmetrics4.go
+++ b/examples/getmetrics4.go
@@ -41,7 +41,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"log"
 	"os"
 	"sort"

--- a/examples/gitissue1.go
+++ b/examples/gitissue1.go
@@ -5,7 +5,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"io"
 )
 

--- a/examples/gitissue2.go
+++ b/examples/gitissue2.go
@@ -5,7 +5,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"io"
 	"io/ioutil"
 )

--- a/examples/gitissue2_2.go
+++ b/examples/gitissue2_2.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"io"
 	"os"
 )

--- a/examples/gonuts1.go
+++ b/examples/gonuts1.go
@@ -6,7 +6,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"io"
 )
 

--- a/examples/gonuts10.go
+++ b/examples/gonuts10.go
@@ -25,7 +25,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var data = []byte(`

--- a/examples/gonuts10seq.go
+++ b/examples/gonuts10seq.go
@@ -25,7 +25,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"strings"
 )
 

--- a/examples/gonuts11seq.go
+++ b/examples/gonuts11seq.go
@@ -12,7 +12,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"io"
 )
 

--- a/examples/gonuts12seq.go
+++ b/examples/gonuts12seq.go
@@ -43,7 +43,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"io"
 )
 

--- a/examples/gonuts1a.go
+++ b/examples/gonuts1a.go
@@ -6,7 +6,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"io"
 )
 

--- a/examples/gonuts2.go
+++ b/examples/gonuts2.go
@@ -11,7 +11,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var xmlmsg1 = []byte(`<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">

--- a/examples/gonuts3.go
+++ b/examples/gonuts3.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var xmldata = []byte(`

--- a/examples/gonuts4.go
+++ b/examples/gonuts4.go
@@ -6,7 +6,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var xmldata = []byte(`

--- a/examples/gonuts5.go
+++ b/examples/gonuts5.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var xmlData = []byte(`<?xml version="1.0" encoding="UTF-8"?>

--- a/examples/gonuts5a.go
+++ b/examples/gonuts5a.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var xmlData = []byte(`<?xml version="1.0" encoding="UTF-8"?>

--- a/examples/gonuts6.go
+++ b/examples/gonuts6.go
@@ -21,7 +21,7 @@ func main() {
 package main
 
 import "fmt"
-import "github.com/clbanning/mxj"
+import "github.com/clbanning/mxj/v2"
 
 func main() {
 	m, err := mxj.NewMapJson(s)

--- a/examples/gonuts9.go
+++ b/examples/gonuts9.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var data = []byte(`<root>

--- a/examples/goofy_map.go
+++ b/examples/goofy_map.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 func main() {

--- a/examples/jpath.go
+++ b/examples/jpath.go
@@ -56,7 +56,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var data = []byte(`

--- a/examples/leafnodes.go
+++ b/examples/leafnodes.go
@@ -5,7 +5,7 @@ package main
 import (
    "fmt"
 
-   "github.com/clbanning/mxj"
+   "github.com/clbanning/mxj/v2"
 )
 
 func main() {

--- a/examples/order.go
+++ b/examples/order.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var data = `<node>

--- a/examples/partial.go
+++ b/examples/partial.go
@@ -5,7 +5,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var source = []byte(`<a>

--- a/examples/reddit01.go
+++ b/examples/reddit01.go
@@ -5,7 +5,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var data = []byte(`<app>

--- a/examples/reddit02.go
+++ b/examples/reddit02.go
@@ -5,7 +5,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 var data = []byte(`<app>

--- a/examples/x2jcmd.go
+++ b/examples/x2jcmd.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"github.com/clbanning/mxj/x2j"
+	"github.com/clbanning/mxj/v2/x2j"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/clbanning/mxj/v2
 
 go 1.15
+
+require github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/j2x/j2x.go
+++ b/j2x/j2x.go
@@ -7,7 +7,7 @@
 package j2x
 
 import (
-	. "github.com/clbanning/mxj"
+	. "github.com/clbanning/mxj/v2"
 	"io"
 )
 

--- a/x2j-wrapper/reader2j.go
+++ b/x2j-wrapper/reader2j.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 // ToMap() - parse a XML io.Reader to a map[string]interface{}

--- a/x2j-wrapper/x2j.go
+++ b/x2j-wrapper/x2j.go
@@ -81,7 +81,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 // If X2jCharsetReader != nil, it will be used to decode the doc or stream if required

--- a/x2j-wrapper/x2j_bulk.go
+++ b/x2j-wrapper/x2j_bulk.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 // XmlMsgsFromFileAsJson()

--- a/x2j-wrapper/x2j_findPath.go
+++ b/x2j-wrapper/x2j_findPath.go
@@ -8,7 +8,7 @@ package x2j
 import (
 	"strings"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 //----------------------------- find all paths to a key --------------------------------

--- a/x2j-wrapper/x2j_valuesAt.go
+++ b/x2j-wrapper/x2j_valuesAt.go
@@ -10,7 +10,7 @@ package x2j
 import (
 	"strings"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 // ------------------- sweep up everything for some point in the node tree ---------------------

--- a/x2j-wrapper/x2j_valuesFrom.go
+++ b/x2j-wrapper/x2j_valuesFrom.go
@@ -9,7 +9,7 @@ package x2j
 import (
 	"strings"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 // ------------------- sweep up everything for some point in the node tree ---------------------

--- a/x2j-wrapper/x2m_bulk.go
+++ b/x2j-wrapper/x2m_bulk.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 // XmlMsgsFromFile()

--- a/x2j/x2j.go
+++ b/x2j/x2j.go
@@ -7,7 +7,7 @@
 package x2j
 
 import (
-	. "github.com/clbanning/mxj"
+	. "github.com/clbanning/mxj/v2"
 	"io"
 )
 


### PR DESCRIPTION
This prevents `go.mod` and `go.sum` generated with `go mod tidy` from picking up `github.com/clbanning/mxj v1.8.4`.

Incidentally, `go mod tidy` also finds `github.com/google/go-cmp` which is used in global_map_prefix_test.go.

Thanks!