### PR TITLE
MapSeq To XML Performance Improvement: >4000x speedup

### DIFF
--- a/xmlseq_test.go
+++ b/xmlseq_test.go
@@ -81,17 +81,17 @@ func TestXmlSeqDecodeError(t *testing.T) {
 }
 
 func BenchmarkMapToXml(b *testing.B) {
+	xmlBytes, err := os.ReadFile("./largexml.xml")
+	if err != nil {
+		b.Fatal("err:", err)
+	}
+
+	msv, err := NewMapXmlSeq(xmlBytes)
+	if err != nil {
+		b.Fatal("err:", err)
+	}
+
 	for i := 0; i < b.N; i++ {
-		xmlBytes, err := os.ReadFile("./largexml.xml")
-		if err != nil {
-			b.Fatal("err:", err)
-		}
-
-		msv, err := NewMapXmlSeq(xmlBytes)
-		if err != nil {
-			b.Fatal("err:", err)
-		}
-
 		_, err = msv.XmlIndent("", "  ")
 		if err != nil {
 			b.Fatal("err:", err)

--- a/xmlseq_test.go
+++ b/xmlseq_test.go
@@ -3,6 +3,7 @@ package mxj
 import (
 	"fmt"
 	"io"
+	"os"
 	"testing"
 )
 
@@ -77,4 +78,21 @@ func TestXmlSeqDecodeError(t *testing.T) {
 		t.Fatal("didn't catch EndElement error")
 	}
 	fmt.Println("err ok:", err)
+}
+
+func BenchmarkMapToXml(b *testing.B) {
+	xmlBytes, err := os.ReadFile("./largexml.xml")
+	if err != nil {
+		b.Fatal("err:", err)
+	}
+
+	msv, err := NewMapXmlSeq(xmlBytes)
+	if err != nil {
+		b.Fatal("err:", err)
+	}
+
+	_, err = msv.XmlIndent("", "  ")
+	if err != nil {
+		b.Fatal("err:", err)
+	}
 }

--- a/xmlseq_test.go
+++ b/xmlseq_test.go
@@ -81,18 +81,20 @@ func TestXmlSeqDecodeError(t *testing.T) {
 }
 
 func BenchmarkMapToXml(b *testing.B) {
-	xmlBytes, err := os.ReadFile("./largexml.xml")
-	if err != nil {
-		b.Fatal("err:", err)
-	}
+	for i := 0; i < b.N; i++ {
+		xmlBytes, err := os.ReadFile("./largexml.xml")
+		if err != nil {
+			b.Fatal("err:", err)
+		}
 
-	msv, err := NewMapXmlSeq(xmlBytes)
-	if err != nil {
-		b.Fatal("err:", err)
-	}
+		msv, err := NewMapXmlSeq(xmlBytes)
+		if err != nil {
+			b.Fatal("err:", err)
+		}
 
-	_, err = msv.XmlIndent("", "  ")
-	if err != nil {
-		b.Fatal("err:", err)
+		_, err = msv.XmlIndent("", "  ")
+		if err != nil {
+			b.Fatal("err:", err)
+		}
 	}
 }


### PR DESCRIPTION
## Description
When converting a `MapSeq` to an XML string, we build the string by performing concatenations using `+` which results in a very (very) large amount of memory allocated when dealing with medium/large XML documents. This change uses a `string.Builder` instead when constructing the XML string. This results in a speedup of at least 4000x.

## Test Results
### Hardware Info
```
Model Name: MacBook Air, 2020
Chip: Apple M1
Total Number of Cores: 8 (4 performance and 4 efficiency)
Memory: 16 GB
MacOS: Sonoma 14.0
```

When working with a 6.5MB XML document:

### Before
```
goos: darwin
goarch: arm64
pkg: github.com/clbanning/mxj/v2
BenchmarkMapToXml-8            1        145618444209 ns/op      1729915592448 B/op       2201337 allocs/op
PASS
ok      github.com/clbanning/mxj/v2     145.830s
```

### After
```
goos: darwin
goarch: arm64
pkg: github.com/clbanning/mxj/v2
BenchmarkMapToXml-8           30          34505182 ns/op        55925730 B/op     208847 allocs/op
PASS
ok      github.com/clbanning/mxj/v2     2.341s
```
